### PR TITLE
Update tooltip.jsx

### DIFF
--- a/src/utils/tooltip.jsx
+++ b/src/utils/tooltip.jsx
@@ -8,7 +8,7 @@ import {
 
 import {
   default as TableTooltipStyle
-} from '../tooltip/table';
+} from '../tooltip/Table';
 
 
 export default class Tooltip extends Component {


### PR DESCRIPTION
the `table` directory is capitalized and causes an error on my Heroku server. saying module not found.
Please merge this.
